### PR TITLE
Add GitHub Actions workflow for publishing Docker container

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,39 @@
+name: Publish Docker Container
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: 'Docker image tag'
+        required: false
+        default: 'latest'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 8
+          cache: 'maven'
+
+      - name: Build distribution with Maven
+        run: mvn clean package
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: partnersinhealth/openmrs-distro-zl:${{ github.event.inputs.image_tag }}


### PR DESCRIPTION
The PR adds a manual action to publish partnersinhealth/openmrs-distro-zl:latest to dockerhub.  We will need to create this repository, and create appropriate secrets for the action before publishing.  Once the workflow is tested we can add it to the current build chain, or alternately could set a cron to check if the dependency snapshots have been updated.

I don't currently have acess to make the changes on the dockerhub org, I will add dockerhub administration as a post-standup topic.